### PR TITLE
Indicate that the hardlink command works on directories

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,5 +1,5 @@
 # hardlink
-a simple command-line utility that implements hardlinks on Mac OsX
+a simple command-line utility that implements directory hardlinks on Mac OsX
 
 to link: `hardlink source destination`  
 to unlink: `hardlink -u destination`

--- a/hardlink.c
+++ b/hardlink.c
@@ -2,7 +2,7 @@
 #include <stdio.h>
 #include <string.h>
 /*
-On Mac OSX, we can't create hard links using the ln command..
+On Mac OSX, we can't create hard links on directories using the ln command..
 
 Install:
  make


### PR DESCRIPTION
Hi,
I added few words in the comments of your _hardlink_ command. Since the ln command from Mac OS X _can_ perform hard links (just not on directories :-)), I precised that this one can perform directory hardlinks, which ln cannot. 
