### PR TITLE
Fix error when directory '/usr/local/bin/' does not exist.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,4 +9,9 @@ clean:
 	rm ${OUTPUT}
 
 install: all
+
+	# Create directory & set permissions if doesn't exist
+	mkdir -pv -m 755 /usr/local/bin/
+
+	# Copy hardlink output executable 
 	cp ${OUTPUT} /usr/local/bin/


### PR DESCRIPTION
Great little utility. On a fresh system I ran into minor error when folder doesn't exist. This commit works around this issue by creating the folder(s) needed. If the folders exist already there should be no error.
