### PR TITLE
Fixing Makefile for 10.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ COMPILER = $(GCC)
 ifeq ($(COMPILER),)
 COMPILER=gcc
 endif
+ifeq ($(PREFIX),)
+PREFIX=./
+endif
 
 all: 
 	$(COMPILER) "$(SOURCE)" -o "$(OUTPUT)"


### PR DESCRIPTION
This fixes the breaking build on Mountain Lion, last change needed! (i hope!)
